### PR TITLE
Bug fix for react context issues

### DIFF
--- a/frontend/src/context/PreferenceContext.js
+++ b/frontend/src/context/PreferenceContext.js
@@ -29,8 +29,8 @@ const PreferenceProvider = ({ children }) => {
         if (Object.keys(storedPreferences).length > 0) {
             const storedDiets = storedPreferences.dietaryRequirements; 
             const storedAllergies = storedPreferences.allergies;
-            const storedPrepTime = storedPreferences.prepTime;
-            const storedCuisine = storedPreferences.cuisine;
+            const storedPrepTime = storedPreferences.maxPrepTime;
+            const storedCuisine = storedPreferences.cuisines;
             const storedNutrition = storedPreferences.nutrition;
 
             const storedServingSize = storedPreferences.servingSize;


### PR DESCRIPTION
There was a bug where if a pref object was in local storage, React would not load it into its context properly. This was due to accessing an object property with a typo